### PR TITLE
Output actual suspend time

### DIFF
--- a/examples/spawn.cgrind
+++ b/examples/spawn.cgrind
@@ -479,7 +479,7 @@ fn={erlang,setelement,3}
 1 552
 fl=pseudo
 fn=suspend
-1 0
+1 468
 fl=dict
 fn={dict,maybe_expand_aux,2}
 1 279
@@ -1243,7 +1243,7 @@ calls=12 1
 1 0
 fl=pseudo
 fn=suspend
-1 0
+1 181
 fl=erl_eval
 fn={erl_eval,expr_list,4}
 1 2
@@ -1414,7 +1414,7 @@ calls=1 1
 1 157
 fl=pseudo
 fn=suspend
-1 0
+1 623
 fl=erl_eval
 fn={erl_eval,'-expr/5-fun-1-',4}
 1 1

--- a/examples/suspend
+++ b/examples/suspend
@@ -1,0 +1,10 @@
+#!/usr/bin/env escript
+
+main([]) ->
+    fprof:start(),
+    fprof:trace([start]),
+    spawn(fun() -> timer:sleep(10) end),
+    timer:sleep(20),
+    fprof:trace([stop]),
+    fprof:profile(),
+    fprof:analyse([{dest, "suspend.fprof"}]).

--- a/examples/suspend.cgrind
+++ b/examples/suspend.cgrind
@@ -1,0 +1,1324 @@
+events: Time
+summary: 24264
+fl=escript
+fn={escript,eval_exprs,5}
+1 12
+cfl=erl_eval
+cfn={erl_eval,expr,5}
+calls=3 1
+1 23821
+cfl=fprof
+cfn={fprof,just_call,2}
+calls=0 1
+1 4
+cfl=escript
+cfn={escript,eval_exprs,5}
+calls=3 1
+1 0
+fl=erl_eval
+fn={erl_eval,local_func,5}
+1 0
+cfl=escript
+cfn={escript,eval_exprs,5}
+calls=0 1
+1 23833
+fl=erl_eval
+fn={erl_eval,expr,5}
+1 38
+cfl=erl_eval
+cfn={erl_eval,do_apply,6}
+calls=2 1
+1 22919
+cfl=erl_eval
+cfn={erl_eval,expr_list,4}
+calls=3 1
+1 849
+cfl=erl_lint
+cfn={erl_lint,used_vars,2}
+calls=1 1
+1 576
+cfl=erl_eval
+cfn={erl_eval,hide_calls,2}
+calls=1 1
+1 213
+cfl=erl_eval
+cfn={erl_eval,merge_bindings,2}
+calls=3 1
+1 17
+cfl=erl_eval
+cfn={erl_eval,ret_expr,3}
+calls=9 1
+1 9
+cfl=erl_eval
+cfn={erl_eval,bif,5}
+calls=1 1
+1 8
+cfl=erl_internal
+cfn={erl_internal,bif,3}
+calls=2 1
+1 3
+cfl=orddict
+cfn={orddict,filter,2}
+calls=1 1
+1 1
+cfl=erl_internal
+cfn={erl_internal,bif,2}
+calls=1 1
+1 1
+cfl=erl_eval
+cfn={erl_eval,expr,5}
+calls=6 1
+1 0
+fl=erl_eval
+fn={erl_eval,do_apply,6}
+1 17
+cfl=error_handler
+cfn={error_handler,undefined_function,3}
+calls=1 1
+1 22877
+cfl=fprof
+cfn={fprof,trace,1}
+calls=1 1
+1 24
+cfl=erlang
+cfn={erlang,spawn,1}
+calls=1 1
+1 4
+cfl=erl_eval
+cfn={erl_eval,ret_expr,3}
+calls=2 1
+1 4
+fl=error_handler
+fn={error_handler,undefined_function,3}
+1 5
+cfl=timer
+cfn={timer,sleep,1}
+calls=1 1
+1 21236
+cfl=error_handler
+cfn={error_handler,ensure_loaded,1}
+calls=1 1
+1 1635
+cfl=erlang
+cfn={erlang,function_exported,3}
+calls=1 1
+1 1
+fl=pseudo
+fn=suspend
+1 22708
+fl=timer
+fn={timer,sleep,1}
+1 110
+cfl=pseudo
+cfn=suspend
+calls=1 1
+1 21126
+fl=error_handler
+fn={error_handler,ensure_loaded,1}
+1 2
+cfl=code
+cfn={code,ensure_loaded,1}
+calls=1 1
+1 1632
+cfl=erlang
+cfn={erlang,whereis,1}
+calls=1 1
+1 1
+fl=code
+fn={code,ensure_loaded,1}
+1 1
+cfl=code
+cfn={code,call,1}
+calls=1 1
+1 1631
+fl=code
+fn={code,call,1}
+1 1
+cfl=code_server
+cfn={code_server,call,2}
+calls=1 1
+1 1630
+fl=code_server
+fn={code_server,call,2}
+1 48
+cfl=pseudo
+cfn=suspend
+calls=1 1
+1 1582
+fl=erl_eval
+fn={erl_eval,expr_list,4}
+1 3
+cfl=erl_eval
+cfn={erl_eval,expr_list,6}
+calls=3 1
+1 846
+fl=erl_eval
+fn={erl_eval,expr_list,6}
+1 17
+cfl=erl_eval
+cfn={erl_eval,merge_bindings,2}
+calls=3 1
+1 12
+cfl=lists
+cfn={lists,reverse,1}
+calls=3 1
+1 4
+cfl=erl_eval
+cfn={erl_eval,expr_list,6}
+calls=3 1
+1 0
+cfl=erl_eval
+cfn={erl_eval,expr,5}
+calls=3 1
+1 0
+fl=erl_lint
+fn={erl_lint,used_vars,2}
+1 7
+cfl=erl_lint
+cfn={erl_lint,start,0}
+calls=1 1
+1 227
+cfl=erl_lint
+cfn={erl_lint,exprs,3}
+calls=1 1
+1 192
+cfl=erl_lint
+cfn={erl_lint,zip_file_and_line,2}
+calls=1 1
+1 147
+cfl=lists
+cfn={lists,foldl,3}
+calls=2 1
+1 2
+cfl=orddict
+cfn={orddict,from_list,1}
+calls=1 1
+1 1
+fl=fprof
+fn={fprof,just_call,2}
+1 400
+cfl=erlang
+cfn={erlang,demonitor,1}
+calls=1 1
+1 39
+cfl=erlang
+cfn={erlang,monitor,2}
+calls=1 1
+1 4
+cfl=erl_eval
+cfn={erl_eval,ret_expr,3}
+calls=1 1
+1 1
+cfl=pseudo
+cfn=suspend
+calls=1 1
+1 0
+fl=lists
+fn={lists,foldl,3}
+1 34
+cfl=erl_lint
+cfn={erl_lint,'-fun_clauses/3-fun-0-',3}
+calls=1 1
+1 166
+cfl=dict
+cfn={dict,'-from_list/1-fun-0-',2}
+calls=1 1
+1 41
+cfl=erl_lint
+cfn={erl_lint,'-expr_list/3-fun-0-',3}
+calls=1 1
+1 6
+cfl=lists
+cfn={lists,foldl,3}
+calls=3 1
+1 0
+fl=erl_lint
+fn={erl_lint,start,0}
+1 1
+cfl=erl_lint
+cfn={erl_lint,start,2}
+calls=1 1
+1 226
+fl=erl_lint
+fn={erl_lint,start,2}
+1 35
+cfl=dict
+cfn={dict,from_list,1}
+calls=1 1
+1 49
+cfl=erl_lint
+cfn={erl_lint,bool_option,4}
+calls=14 1
+1 28
+cfl=ordsets
+cfn={ordsets,from_list,1}
+calls=1 1
+1 26
+cfl=gb_sets
+cfn={gb_sets,from_list,1}
+calls=2 1
+1 26
+cfl=erl_lint
+cfn={erl_lint,'-start/2-lc$^0/1-0-',1}
+calls=1 1
+1 23
+cfl=dict
+cfn={dict,new,0}
+calls=5 1
+1 15
+cfl=erl_lint
+cfn={erl_lint,'-start/2-lc$^1/1-1-',1}
+calls=1 1
+1 7
+cfl=ordsets
+cfn={ordsets,is_element,2}
+calls=1 1
+1 6
+cfl=sets
+cfn={sets,new,0}
+calls=1 1
+1 3
+cfl=gb_sets
+cfn={gb_sets,empty,0}
+calls=3 1
+1 3
+cfl=erl_lint
+cfn={erl_lint,pseudolocals,0}
+calls=3 1
+1 3
+cfl=erl_lint
+cfn={erl_lint,value_option,7}
+calls=1 1
+1 2
+fl=erl_eval
+fn={erl_eval,hide_calls,2}
+1 3
+cfl=erl_eval
+cfn={erl_eval,hide,3}
+calls=1 1
+1 206
+cfl=dict
+cfn={dict,new,0}
+calls=1 1
+1 4
+fl=erl_eval
+fn={erl_eval,hide,3}
+1 190
+cfl=erlang
+cfn={erlang,tuple_to_list,1}
+calls=8 1
+1 8
+cfl=erlang
+cfn={erlang,list_to_tuple,1}
+calls=8 1
+1 8
+cfl=erl_eval
+cfn={erl_eval,hide,3}
+calls=68 1
+1 0
+fl=erl_lint
+fn={erl_lint,exprs,3}
+1 12
+cfl=erl_lint
+cfn={erl_lint,expr,3}
+calls=2 1
+1 182
+cfl=erl_lint
+cfn={erl_lint,vtupdate,2}
+calls=4 1
+1 8
+cfl=erl_lint
+cfn={erl_lint,exprs,3}
+calls=2 1
+1 0
+fl=erl_lint
+fn={erl_lint,expr,3}
+1 29
+cfl=erl_lint
+cfn={erl_lint,fun_clauses,3}
+calls=1 1
+1 181
+cfl=erl_lint
+cfn={erl_lint,expr_list,3}
+calls=1 1
+1 20
+cfl=erl_lint
+cfn={erl_lint,keyword_warning,3}
+calls=1 1
+1 16
+cfl=erl_lint
+cfn={erl_lint,check_remote_function,5}
+calls=1 1
+1 13
+fl=erl_lint
+fn={erl_lint,fun_clauses,3}
+1 6
+cfl=lists
+cfn={lists,foldl,3}
+calls=1 1
+1 169
+cfl=erlang
+cfn={erlang,setelement,3}
+calls=2 1
+1 2
+cfl=erl_lint
+cfn={erl_lint,vtold,2}
+calls=1 1
+1 2
+cfl=erl_lint
+cfn={erl_lint,vt_no_unused,1}
+calls=1 1
+1 2
+fl=erl_lint
+fn={erl_lint,'-fun_clauses/3-fun-0-',3}
+1 3
+cfl=erl_lint
+cfn={erl_lint,fun_clause,3}
+calls=1 1
+1 161
+cfl=erl_lint
+cfn={erl_lint,vtmerge,2}
+calls=1 1
+1 2
+fl=erl_lint
+fn={erl_lint,fun_clause,3}
+1 16
+cfl=erl_lint
+cfn={erl_lint,shadow_vars,4}
+calls=1 1
+1 15
+cfl=erl_lint
+cfn={erl_lint,check_old_unused_vars,3}
+calls=1 1
+1 11
+cfl=erl_lint
+cfn={erl_lint,vtupdate,2}
+calls=4 1
+1 10
+cfl=erl_lint
+cfn={erl_lint,check_unused_vars,3}
+calls=1 1
+1 8
+cfl=erl_lint
+cfn={erl_lint,vtsubtract,2}
+calls=2 1
+1 6
+cfl=erl_lint
+cfn={erl_lint,vtold,2}
+calls=2 1
+1 4
+cfl=erl_lint
+cfn={erl_lint,vtmerge,2}
+calls=1 1
+1 2
+cfl=erl_lint
+cfn={erl_lint,guard,3}
+calls=1 1
+1 2
+cfl=erl_lint
+cfn={erl_lint,head,4}
+calls=1 1
+1 1
+cfl=erl_lint
+cfn={erl_lint,exprs,3}
+calls=1 1
+1 0
+fl=erl_lint
+fn={erl_lint,zip_file_and_line,2}
+1 1
+cfl=erl_lint
+cfn={erl_lint,modify_line,2}
+calls=1 1
+1 146
+fl=erl_lint
+fn={erl_lint,modify_line,2}
+1 1
+cfl=erl_lint
+cfn={erl_lint,modify_line1,2}
+calls=1 1
+1 145
+fl=erl_lint
+fn={erl_lint,modify_line1,2}
+1 88
+cfl=erl_lint
+cfn={erl_lint,'-zip_file_and_line/2-fun-1-',2}
+calls=7 1
+1 57
+cfl=erl_lint
+cfn={erl_lint,modify_line1,2}
+calls=20 1
+1 0
+fl=erl_lint
+fn={erl_lint,'-zip_file_and_line/2-fun-1-',2}
+1 7
+cfl=erl_parse
+cfn={erl_parse,set_line,2}
+calls=7 1
+1 50
+fl=erl_parse
+fn={erl_parse,set_line,2}
+1 7
+cfl=erl_scan
+cfn={erl_scan,set_attribute,3}
+calls=7 1
+1 43
+fl=dict
+fn={dict,from_list,1}
+1 2
+cfl=lists
+cfn={lists,foldl,3}
+calls=1 1
+1 44
+cfl=dict
+cfn={dict,new,0}
+calls=1 1
+1 3
+fl=erl_scan
+fn={erl_scan,set_attribute,3}
+1 20
+cfl=erl_scan
+cfn={erl_scan,set_attr,3}
+calls=7 1
+1 23
+fl=dict
+fn={dict,'-from_list/1-fun-0-',2}
+1 1
+cfl=dict
+cfn={dict,store,3}
+calls=1 1
+1 40
+fl=dict
+fn={dict,store,3}
+1 3
+cfl=dict
+cfn={dict,on_bucket,3}
+calls=1 1
+1 30
+cfl=dict
+cfn={dict,maybe_expand,2}
+calls=1 1
+1 4
+cfl=dict
+cfn={dict,get_slot,2}
+calls=1 1
+1 3
+fl=erlang
+fn={erlang,demonitor,1}
+1 39
+fl=ordsets
+fn={ordsets,from_list,1}
+1 3
+cfl=lists
+cfn={lists,usort,1}
+calls=3 1
+1 27
+fl=dict
+fn={dict,on_bucket,3}
+1 25
+cfl=erlang
+cfn={erlang,setelement,3}
+calls=3 1
+1 3
+cfl=dict
+cfn={dict,'-store/3-fun-0-',3}
+calls=1 1
+1 2
+fl=erl_eval
+fn={erl_eval,merge_bindings,2}
+1 14
+cfl=orddict
+cfn={orddict,to_list,1}
+calls=6 1
+1 8
+cfl=lists
+cfn={lists,foldl,3}
+calls=6 1
+1 7
+fl=erl_lint
+fn={erl_lint,bool_option,4}
+1 14
+cfl=lists
+cfn={lists,foldl,3}
+calls=14 1
+1 14
+fl=lists
+fn={lists,usort,1}
+1 3
+cfl=lists
+cfn={lists,usplit_2,5}
+calls=1 1
+1 24
+fl=gb_sets
+fn={gb_sets,from_list,1}
+1 4
+cfl=gb_sets
+cfn={gb_sets,from_ordset,1}
+calls=2 1
+1 18
+cfl=ordsets
+cfn={ordsets,from_list,1}
+calls=2 1
+1 4
+fl=lists
+fn={lists,usplit_2,5}
+1 5
+cfl=lists
+cfn={lists,usplit_2_1,6}
+calls=1 1
+1 21
+cfl=lists
+cfn={lists,umergel,3}
+calls=1 1
+1 17
+cfl=lists
+cfn={lists,usplit_2,5}
+calls=3 1
+1 0
+fl=fprof
+fn={fprof,trace,1}
+1 2
+cfl=fprof
+cfn={fprof,call,1}
+calls=1 1
+1 22
+fl=erl_scan
+fn={erl_scan,set_attr,3}
+1 16
+cfl=erl_lint
+cfn={erl_lint,'-zip_file_and_line/2-fun-0-',2}
+calls=7 1
+1 7
+fl=erl_lint
+fn={erl_lint,'-start/2-lc$^0/1-0-',1}
+1 23
+cfl=erl_lint
+cfn={erl_lint,'-start/2-lc$^0/1-0-',1}
+calls=14 1
+1 0
+fl=fprof
+fn={fprof,call,1}
+1 6
+cfl=fprof
+cfn={fprof,just_call,2}
+calls=1 1
+1 13
+cfl=erlang
+cfn={erlang,whereis,1}
+calls=1 1
+1 3
+fl=dict
+fn={dict,new,0}
+1 15
+cfl=dict
+cfn={dict,mk_seg,1}
+calls=7 1
+1 7
+fl=lists
+fn={lists,usplit_2_1,6}
+1 2
+cfl=lists
+cfn={lists,usplit_2_1,6}
+calls=1 1
+1 0
+cfl=lists
+cfn={lists,usplit_2,5}
+calls=1 1
+1 0
+fl=erl_lint
+fn={erl_lint,expr_list,3}
+1 5
+cfl=erl_lint
+cfn={erl_lint,vtold,2}
+calls=1 1
+1 2
+cfl=erl_lint
+cfn={erl_lint,vtnew,2}
+calls=1 1
+1 2
+cfl=erl_lint
+cfn={erl_lint,vtmerge,2}
+calls=1 1
+1 2
+cfl=lists
+cfn={lists,foldl,3}
+calls=1 1
+1 0
+fl=gb_sets
+fn={gb_sets,from_ordset,1}
+1 4
+cfl=gb_sets
+cfn={gb_sets,balance_list,2}
+calls=2 1
+1 14
+fl=erl_lint
+fn={erl_lint,vtupdate,2}
+1 9
+cfl=orddict
+cfn={orddict,merge,3}
+calls=8 1
+1 8
+cfl=pseudo
+cfn=garbage_collect
+calls=1 1
+1 1
+fl=lists
+fn={lists,umergel,3}
+1 4
+cfl=lists
+cfn={lists,umerge2_2,4}
+calls=1 1
+1 10
+cfl=lists
+cfn={lists,rumergel,3}
+calls=1 1
+1 4
+cfl=lists
+cfn={lists,umergel,3}
+calls=1 1
+1 0
+fl=erl_lint
+fn={erl_lint,keyword_warning,3}
+1 16
+fl=erl_lint
+fn={erl_lint,shadow_vars,4}
+1 4
+cfl=erl_lint
+cfn={erl_lint,is_warn_enabled,2}
+calls=1 1
+1 6
+cfl=erl_lint
+cfn={erl_lint,vtold,2}
+calls=1 1
+1 2
+cfl=erl_lint
+cfn={erl_lint,vt_no_unsafe,1}
+calls=1 1
+1 2
+cfl=lists
+cfn={lists,foldl,3}
+calls=1 1
+1 0
+fl=orddict
+fn={orddict,filter,2}
+1 14
+fl=gb_sets
+fn={gb_sets,balance_list,2}
+1 4
+cfl=gb_sets
+cfn={gb_sets,balance_list_1,2}
+calls=2 1
+1 10
+fl=erl_eval
+fn={erl_eval,ret_expr,3}
+1 14
+fl=erl_lint
+fn={erl_lint,check_remote_function,5}
+1 3
+cfl=erl_lint
+cfn={erl_lint,deprecated_function,5}
+calls=1 1
+1 6
+cfl=erl_lint
+cfn={erl_lint,format_function,5}
+calls=1 1
+1 3
+cfl=erl_lint
+cfn={erl_lint,check_qlc_hrl,5}
+calls=1 1
+1 1
+fl=orddict
+fn={orddict,merge,3}
+1 12
+fl=erl_lint
+fn={erl_lint,vtold,2}
+1 6
+cfl=orddict
+cfn={orddict,filter,2}
+calls=6 1
+1 6
+fl=ordsets
+fn={ordsets,is_element,2}
+1 11
+cfl=ordsets
+cfn={ordsets,is_element,2}
+calls=9 1
+1 0
+fl=erl_lint
+fn={erl_lint,check_old_unused_vars,3}
+1 3
+cfl=erl_lint
+cfn={erl_lint,unused_vars,3}
+calls=1 1
+1 5
+cfl=erl_lint
+cfn={erl_lint,vtold,2}
+calls=1 1
+1 2
+cfl=erl_lint
+cfn={erl_lint,warn_unused_vars,3}
+calls=1 1
+1 1
+fl=lists
+fn={lists,umerge2_2,4}
+1 5
+cfl=lists
+cfn={lists,umerge2_1,5}
+calls=2 1
+1 9
+cfl=lists
+cfn={lists,reverse,2}
+calls=1 1
+1 1
+cfl=lists
+cfn={lists,umerge2_2,4}
+calls=1 1
+1 0
+fl=gb_sets
+fn={gb_sets,balance_list_1,2}
+1 10
+cfl=gb_sets
+cfn={gb_sets,balance_list_1,2}
+calls=4 1
+1 0
+fl=erl_lint
+fn={erl_lint,vtnew,2}
+1 5
+cfl=orddict
+cfn={orddict,filter,2}
+calls=5 1
+1 5
+fl=erl_lint
+fn={erl_lint,unused_vars,3}
+1 4
+cfl=erl_lint
+cfn={erl_lint,vtnew,2}
+calls=2 1
+1 4
+cfl=orddict
+cfn={orddict,filter,2}
+calls=2 1
+1 2
+fl=lists
+fn={lists,umerge2_1,5}
+1 4
+cfl=lists
+cfn={lists,umerge2_2,4}
+calls=2 1
+1 0
+cfl=lists
+cfn={lists,umerge2_1,5}
+calls=2 1
+1 0
+fl=orddict
+fn={orddict,to_list,1}
+1 8
+fl=erlang
+fn={erlang,tuple_to_list,1}
+1 8
+fl=erlang
+fn={erlang,list_to_tuple,1}
+1 8
+fl=erl_lint
+fn={erl_lint,check_unused_vars,3}
+1 2
+cfl=erl_lint
+cfn={erl_lint,unused_vars,3}
+calls=1 1
+1 5
+cfl=erl_lint
+cfn={erl_lint,warn_unused_vars,3}
+calls=1 1
+1 1
+fl=erl_eval
+fn={erl_eval,bif,5}
+1 1
+cfl=erl_eval
+cfn={erl_eval,do_apply,6}
+calls=1 1
+1 7
+fl=erl_lint
+fn={erl_lint,'-zip_file_and_line/2-fun-0-',2}
+1 7
+fl=erl_lint
+fn={erl_lint,'-start/2-lc$^1/1-1-',1}
+1 7
+cfl=erl_lint
+cfn={erl_lint,'-start/2-lc$^1/1-1-',1}
+calls=3 1
+1 0
+fl=dict
+fn={dict,mk_seg,1}
+1 7
+fl=erlang
+fn={erlang,setelement,3}
+1 6
+fl=erl_lint
+fn={erl_lint,vtsubtract,2}
+1 2
+cfl=erl_lint
+cfn={erl_lint,vtnew,2}
+calls=2 1
+1 4
+fl=erl_lint
+fn={erl_lint,vtmerge,2}
+1 3
+cfl=orddict
+cfn={orddict,merge,3}
+calls=3 1
+1 3
+fl=erl_lint
+fn={erl_lint,is_warn_enabled,2}
+1 1
+cfl=ordsets
+cfn={ordsets,is_element,2}
+calls=1 1
+1 5
+fl=erl_lint
+fn={erl_lint,deprecated_function,5}
+1 3
+cfl=otp_internal
+cfn={otp_internal,obsolete,3}
+calls=1 1
+1 3
+fl=erl_lint
+fn={erl_lint,'-expr_list/3-fun-0-',3}
+1 3
+cfl=erl_lint
+cfn={erl_lint,vtmerge_pat,2}
+calls=1 1
+1 2
+cfl=erl_lint
+cfn={erl_lint,expr,3}
+calls=1 1
+1 0
+fl=lists
+fn={lists,rumergel,3}
+1 2
+cfl=lists
+cfn={lists,reverse,2}
+calls=1 1
+1 1
+cfl=lists
+cfn={lists,umergel,3}
+calls=1 1
+1 0
+fl=lists
+fn={lists,reverse,1}
+1 4
+fl=erlang
+fn={erlang,whereis,1}
+1 4
+fl=erlang
+fn={erlang,spawn,1}
+1 2
+cfl=erlang
+cfn={erlang,spawn,3}
+calls=1 1
+1 2
+fl=erlang
+fn={erlang,monitor,2}
+1 4
+fl=dict
+fn={dict,maybe_expand,2}
+1 1
+cfl=dict
+cfn={dict,maybe_expand_aux,2}
+calls=1 1
+1 3
+fl=sets
+fn={sets,new,0}
+1 2
+cfl=sets
+cfn={sets,mk_seg,1}
+calls=1 1
+1 1
+fl=otp_internal
+fn={otp_internal,obsolete,3}
+1 2
+cfl=otp_internal
+cfn={otp_internal,obsolete_1,3}
+calls=1 1
+1 1
+fl=gb_sets
+fn={gb_sets,empty,0}
+1 3
+fl=erl_lint
+fn={erl_lint,pseudolocals,0}
+1 3
+fl=erl_lint
+fn={erl_lint,format_function,5}
+1 2
+cfl=erl_lint
+cfn={erl_lint,is_format_function,2}
+calls=1 1
+1 1
+fl=erl_internal
+fn={erl_internal,bif,3}
+1 3
+fl=dict
+fn={dict,maybe_expand_aux,2}
+1 2
+cfl=erlang
+cfn={erlang,setelement,3}
+calls=1 1
+1 1
+fl=dict
+fn={dict,get_slot,2}
+1 2
+cfl=erlang
+cfn={erlang,phash,2}
+calls=1 1
+1 1
+fl=lists
+fn={lists,reverse,2}
+1 2
+fl=erlang
+fn={erlang,spawn,3}
+1 2
+fl=erl_lint
+fn={erl_lint,warn_unused_vars,3}
+1 2
+fl=erl_lint
+fn={erl_lint,vtmerge_pat,2}
+1 1
+cfl=orddict
+cfn={orddict,merge,3}
+calls=1 1
+1 1
+fl=erl_lint
+fn={erl_lint,vt_no_unused,1}
+1 1
+cfl=erl_lint
+cfn={erl_lint,'-vt_no_unused/1-lc$^0/1-0-',1}
+calls=1 1
+1 1
+fl=erl_lint
+fn={erl_lint,vt_no_unsafe,1}
+1 1
+cfl=erl_lint
+cfn={erl_lint,'-vt_no_unsafe/1-lc$^0/1-0-',1}
+calls=1 1
+1 1
+fl=erl_lint
+fn={erl_lint,value_option,7}
+1 1
+cfl=lists
+cfn={lists,foldl,3}
+calls=1 1
+1 1
+fl=erl_lint
+fn={erl_lint,guard,3}
+1 1
+cfl=erl_lint
+cfn={erl_lint,guard_tests,3}
+calls=1 1
+1 1
+fl=dict
+fn={dict,'-store/3-fun-0-',3}
+1 1
+cfl=dict
+cfn={dict,store_bkt_val,3}
+calls=1 1
+1 1
+fl=sets
+fn={sets,mk_seg,1}
+1 1
+fl=otp_internal
+fn={otp_internal,obsolete_1,3}
+1 1
+fl=orddict
+fn={orddict,from_list,1}
+1 1
+fl=erlang
+fn={erlang,phash,2}
+1 1
+fl=erlang
+fn={erlang,function_exported,3}
+1 1
+fl=erl_lint
+fn={erl_lint,is_format_function,2}
+1 1
+fl=erl_lint
+fn={erl_lint,head,4}
+1 1
+fl=erl_lint
+fn={erl_lint,guard_tests,3}
+1 1
+fl=erl_lint
+fn={erl_lint,check_qlc_hrl,5}
+1 1
+fl=erl_lint
+fn={erl_lint,'-vt_no_unused/1-lc$^0/1-0-',1}
+1 1
+fl=erl_lint
+fn={erl_lint,'-vt_no_unsafe/1-lc$^0/1-0-',1}
+1 1
+fl=erl_internal
+fn={erl_internal,bif,2}
+1 1
+fl=dict
+fn={dict,store_bkt_val,3}
+1 1
+fl=pseudo
+fn=garbage_collect
+1 1
+fl=pseudo
+fn=undefined
+1 0
+cfl=erl_eval
+cfn={erl_eval,local_func,5}
+calls=0 1
+1 23833
+cfl=fprof
+cfn={fprof,just_call,2}
+calls=0 1
+1 427
+cfl=escript
+cfn={escript,eval_exprs,5}
+calls=0 1
+1 4
+fl=erlang
+fn={erlang,apply,2}
+1 3
+cfl=erl_eval
+cfn={erl_eval,'-expr/5-fun-3-',1}
+calls=1 1
+1 13102
+cfl=pseudo
+cfn=suspend
+calls=1 1
+1 43
+fl=erl_eval
+fn={erl_eval,'-expr/5-fun-3-',1}
+1 9
+cfl=erl_eval
+cfn={erl_eval,eval_fun,2}
+calls=1 1
+1 13093
+fl=erl_eval
+fn={erl_eval,eval_fun,2}
+1 1
+cfl=erl_eval
+cfn={erl_eval,eval_fun,6}
+calls=1 1
+1 13092
+fl=erl_eval
+fn={erl_eval,eval_fun,6}
+1 23
+cfl=erl_eval
+cfn={erl_eval,exprs,5}
+calls=1 1
+1 13060
+cfl=erl_eval
+cfn={erl_eval,add_bindings,2}
+calls=1 1
+1 4
+cfl=erl_eval
+cfn={erl_eval,new_bindings,0}
+calls=1 1
+1 2
+cfl=erl_eval
+cfn={erl_eval,guard,4}
+calls=1 1
+1 2
+cfl=erl_eval
+cfn={erl_eval,match_list,4}
+calls=1 1
+1 1
+fl=erl_eval
+fn={erl_eval,exprs,5}
+1 1
+cfl=erl_eval
+cfn={erl_eval,expr,5}
+calls=1 1
+1 13059
+fl=erl_eval
+fn={erl_eval,expr,5}
+1 9
+cfl=erl_eval
+cfn={erl_eval,do_apply,6}
+calls=1 1
+1 13031
+cfl=erl_eval
+cfn={erl_eval,expr_list,4}
+calls=1 1
+1 13
+cfl=erl_eval
+cfn={erl_eval,merge_bindings,2}
+calls=1 1
+1 4
+cfl=erl_eval
+cfn={erl_eval,ret_expr,3}
+calls=3 1
+1 3
+cfl=erl_internal
+cfn={erl_internal,bif,3}
+calls=1 1
+1 1
+cfl=erl_eval
+cfn={erl_eval,expr,5}
+calls=2 1
+1 0
+fl=erl_eval
+fn={erl_eval,do_apply,6}
+1 1
+cfl=error_handler
+cfn={error_handler,undefined_function,3}
+calls=1 1
+1 13030
+fl=error_handler
+fn={error_handler,undefined_function,3}
+1 3
+cfl=timer
+cfn={timer,sleep,1}
+calls=1 1
+1 11360
+cfl=error_handler
+cfn={error_handler,ensure_loaded,1}
+calls=1 1
+1 1666
+cfl=erlang
+cfn={erlang,function_exported,3}
+calls=1 1
+1 1
+fl=pseudo
+fn=suspend
+1 12992
+fl=timer
+fn={timer,sleep,1}
+1 69
+cfl=pseudo
+cfn=suspend
+calls=1 1
+1 11291
+fl=error_handler
+fn={error_handler,ensure_loaded,1}
+1 2
+cfl=code
+cfn={code,ensure_loaded,1}
+calls=1 1
+1 1663
+cfl=erlang
+cfn={erlang,whereis,1}
+calls=1 1
+1 1
+fl=code
+fn={code,ensure_loaded,1}
+1 1
+cfl=code
+cfn={code,call,1}
+calls=1 1
+1 1662
+fl=code
+fn={code,call,1}
+1 1
+cfl=code_server
+cfn={code_server,call,2}
+calls=1 1
+1 1661
+fl=code_server
+fn={code_server,call,2}
+1 3
+cfl=pseudo
+cfn=suspend
+calls=1 1
+1 1658
+fl=erl_eval
+fn={erl_eval,expr_list,4}
+1 1
+cfl=erl_eval
+cfn={erl_eval,expr_list,6}
+calls=1 1
+1 12
+fl=erl_eval
+fn={erl_eval,expr_list,6}
+1 5
+cfl=erl_eval
+cfn={erl_eval,merge_bindings,2}
+calls=1 1
+1 4
+cfl=lists
+cfn={lists,reverse,1}
+calls=1 1
+1 1
+cfl=erl_eval
+cfn={erl_eval,expr_list,6}
+calls=1 1
+1 0
+cfl=erl_eval
+cfn={erl_eval,expr,5}
+calls=1 1
+1 0
+fl=erl_eval
+fn={erl_eval,merge_bindings,2}
+1 4
+cfl=orddict
+cfn={orddict,to_list,1}
+calls=2 1
+1 2
+cfl=lists
+cfn={lists,foldl,3}
+calls=2 1
+1 2
+fl=erl_eval
+fn={erl_eval,add_bindings,2}
+1 2
+cfl=orddict
+cfn={orddict,to_list,1}
+calls=1 1
+1 1
+cfl=lists
+cfn={lists,foldl,3}
+calls=1 1
+1 1
+fl=orddict
+fn={orddict,to_list,1}
+1 3
+fl=lists
+fn={lists,foldl,3}
+1 3
+fl=erl_eval
+fn={erl_eval,ret_expr,3}
+1 3
+fl=erl_eval
+fn={erl_eval,new_bindings,0}
+1 1
+cfl=orddict
+cfn={orddict,new,0}
+calls=1 1
+1 1
+fl=erl_eval
+fn={erl_eval,guard,4}
+1 1
+cfl=erl_eval
+cfn={erl_eval,guard0,4}
+calls=1 1
+1 1
+fl=orddict
+fn={orddict,new,0}
+1 1
+fl=lists
+fn={lists,reverse,1}
+1 1
+fl=erlang
+fn={erlang,whereis,1}
+1 1
+fl=erlang
+fn={erlang,function_exported,3}
+1 1
+fl=erl_internal
+fn={erl_internal,bif,3}
+1 1
+fl=erl_eval
+fn={erl_eval,match_list,4}
+1 1
+fl=erl_eval
+fn={erl_eval,guard0,4}
+1 1
+fl=pseudo
+fn=undefined
+1 0
+cfl=erlang
+cfn={erlang,apply,2}
+calls=1 1
+1 13148

--- a/examples/suspend.fprof
+++ b/examples/suspend.fprof
@@ -1,0 +1,806 @@
+%% Analysis results:
+{  analysis_options,
+ [{callers, true},
+  {sort, acc},
+  {totals, false},
+  {details, true}]}.
+
+%                                               CNT       ACC       OWN        
+[{ totals,                                      507,   24.264,    1.712}].  %%%
+
+
+%                                               CNT       ACC       OWN        
+[{ "<0.2.0>",                                   464,undefined,    1.556}].   %%
+
+{[{{erl_eval,local_func,5},                       0,   23.833,    0.002},      
+  {undefined,                                     0,    0.004,    0.000},      
+  {{escript,eval_exprs,5},                        3,    0.000,    0.010}],     
+ { {escript,eval_exprs,5},                        3,   23.837,    0.012},     %
+ [{{erl_eval,expr,5},                             3,   23.821,    0.019},      
+  {{fprof,just_call,2},                           0,    0.004,    0.003},      
+  {{escript,eval_exprs,5},                        3,    0.000,    0.010}]}.    
+
+{[{undefined,                                     0,   23.833,    0.000}],     
+ { {erl_eval,local_func,5},                       0,   23.833,    0.000},     %
+ [{{escript,eval_exprs,5},                        0,   23.833,    0.002}]}.    
+
+{[{{escript,eval_exprs,5},                        3,   23.821,    0.019},      
+  {{erl_eval,expr_list,6},                        3,    0.000,    0.010},      
+  {{erl_eval,expr,5},                             6,    0.000,    0.009}],     
+ { {erl_eval,expr,5},                            12,   23.821,    0.038},     %
+ [{{erl_eval,do_apply,6},                         2,   22.919,    0.015},      
+  {{erl_eval,expr_list,4},                        3,    0.849,    0.003},      
+  {{erl_lint,used_vars,2},                        1,    0.576,    0.007},      
+  {{erl_eval,hide_calls,2},                       1,    0.213,    0.003},      
+  {{erl_eval,merge_bindings,2},                   3,    0.017,    0.008},      
+  {{erl_eval,ret_expr,3},                         9,    0.009,    0.009},      
+  {{erl_eval,bif,5},                              1,    0.008,    0.001},      
+  {{erl_internal,bif,3},                          2,    0.003,    0.003},      
+  {{orddict,filter,2},                            1,    0.001,    0.001},      
+  {{erl_internal,bif,2},                          1,    0.001,    0.001},      
+  {{erl_eval,expr,5},                             6,    0.000,    0.009}]}.    
+
+{[{{erl_eval,expr,5},                             2,   22.919,    0.015},      
+  {{erl_eval,bif,5},                              1,    0.007,    0.002}],     
+ { {erl_eval,do_apply,6},                         3,   22.926,    0.017},     %
+ [{{error_handler,undefined_function,3},          1,   22.877,    0.005},      
+  {{fprof,trace,1},                               1,    0.024,    0.002},      
+  {{erlang,spawn,1},                              1,    0.004,    0.002},      
+  {{erl_eval,ret_expr,3},                         2,    0.004,    0.004}]}.    
+
+{[{{erl_eval,do_apply,6},                         1,   22.877,    0.005}],     
+ { {error_handler,undefined_function,3},          1,   22.877,    0.005},     %
+ [{{timer,sleep,1},                               1,   21.236,    0.110},      
+  {{error_handler,ensure_loaded,1},               1,    1.635,    0.002},      
+  {{erlang,function_exported,3},                  1,    0.001,    0.001}]}.    
+
+{[{{timer,sleep,1},                               1,   21.126,    0.000},      
+  {{code_server,call,2},                          1,    1.582,    0.000},      
+  {{fprof,just_call,2},                           1,    0.000,    0.000}],     
+ { suspend,                                       3,   22.708,    0.000},     %
+ [ ]}.
+
+{[{{error_handler,undefined_function,3},          1,   21.236,    0.110}],     
+ { {timer,sleep,1},                               1,   21.236,    0.110},     %
+ [{suspend,                                       1,   21.126,    0.000}]}.    
+
+{[{{error_handler,undefined_function,3},          1,    1.635,    0.002}],     
+ { {error_handler,ensure_loaded,1},               1,    1.635,    0.002},     %
+ [{{code,ensure_loaded,1},                        1,    1.632,    0.001},      
+  {{erlang,whereis,1},                            1,    0.001,    0.001}]}.    
+
+{[{{error_handler,ensure_loaded,1},               1,    1.632,    0.001}],     
+ { {code,ensure_loaded,1},                        1,    1.632,    0.001},     %
+ [{{code,call,1},                                 1,    1.631,    0.001}]}.    
+
+{[{{code,ensure_loaded,1},                        1,    1.631,    0.001}],     
+ { {code,call,1},                                 1,    1.631,    0.001},     %
+ [{{code_server,call,2},                          1,    1.630,    0.048}]}.    
+
+{[{{code,call,1},                                 1,    1.630,    0.048}],     
+ { {code_server,call,2},                          1,    1.630,    0.048},     %
+ [{suspend,                                       1,    1.582,    0.000}]}.    
+
+{[{{erl_eval,expr,5},                             3,    0.849,    0.003}],     
+ { {erl_eval,expr_list,4},                        3,    0.849,    0.003},     %
+ [{{erl_eval,expr_list,6},                        3,    0.846,    0.010}]}.    
+
+{[{{erl_eval,expr_list,4},                        3,    0.846,    0.010},      
+  {{erl_eval,expr_list,6},                        3,    0.000,    0.007}],     
+ { {erl_eval,expr_list,6},                        6,    0.846,    0.017},     %
+ [{{erl_eval,merge_bindings,2},                   3,    0.012,    0.006},      
+  {{lists,reverse,1},                             3,    0.004,    0.004},      
+  {{erl_eval,expr_list,6},                        3,    0.000,    0.007},      
+  {{erl_eval,expr,5},                             3,    0.000,    0.010}]}.    
+
+{[{{erl_eval,expr,5},                             1,    0.576,    0.007}],     
+ { {erl_lint,used_vars,2},                        1,    0.576,    0.007},     %
+ [{{erl_lint,start,0},                            1,    0.227,    0.001},      
+  {{erl_lint,exprs,3},                            1,    0.192,    0.005},      
+  {{erl_lint,zip_file_and_line,2},                1,    0.147,    0.001},      
+  {{lists,foldl,3},                               2,    0.002,    0.002},      
+  {{orddict,from_list,1},                         1,    0.001,    0.001}]}.    
+
+{[{undefined,                                     0,    0.427,    0.388},      
+  {{fprof,call,1},                                1,    0.013,    0.009},      
+  {{escript,eval_exprs,5},                        0,    0.004,    0.003}],     
+ { {fprof,just_call,2},                           1,    0.444,    0.400},     %
+ [{{erlang,demonitor,1},                          1,    0.039,    0.039},      
+  {{erlang,monitor,2},                            1,    0.004,    0.004},      
+  {{erl_eval,ret_expr,3},                         1,    0.001,    0.001},      
+  {suspend,                                       1,    0.000,    0.000}]}.    
+
+{[{{erl_lint,fun_clauses,3},                      1,    0.169,    0.002},      
+  {{dict,from_list,1},                            1,    0.044,    0.002},      
+  {{erl_lint,bool_option,4},                     14,    0.014,    0.014},      
+  {{erl_eval,merge_bindings,2},                   6,    0.007,    0.007},      
+  {{erl_lint,used_vars,2},                        2,    0.002,    0.002},      
+  {{erl_lint,value_option,7},                     1,    0.001,    0.001},      
+  {{lists,foldl,3},                               3,    0.000,    0.003},      
+  {{erl_lint,shadow_vars,4},                      1,    0.000,    0.001},      
+  {{erl_lint,expr_list,3},                        1,    0.000,    0.002}],     
+ { {lists,foldl,3},                              30,    0.237,    0.034},     %
+ [{{erl_lint,'-fun_clauses/3-fun-0-',3},          1,    0.166,    0.003},      
+  {{dict,'-from_list/1-fun-0-',2},                1,    0.041,    0.001},      
+  {{erl_lint,'-expr_list/3-fun-0-',3},            1,    0.006,    0.003},      
+  {{lists,foldl,3},                               3,    0.000,    0.003}]}.    
+
+{[{{erl_lint,used_vars,2},                        1,    0.227,    0.001}],     
+ { {erl_lint,start,0},                            1,    0.227,    0.001},     %
+ [{{erl_lint,start,2},                            1,    0.226,    0.035}]}.    
+
+{[{{erl_lint,start,0},                            1,    0.226,    0.035}],     
+ { {erl_lint,start,2},                            1,    0.226,    0.035},     %
+ [{{dict,from_list,1},                            1,    0.049,    0.002},      
+  {{erl_lint,bool_option,4},                     14,    0.028,    0.014},      
+  {{ordsets,from_list,1},                         1,    0.026,    0.001},      
+  {{gb_sets,from_list,1},                         2,    0.026,    0.004},      
+  {{erl_lint,'-start/2-lc$^0/1-0-',1},            1,    0.023,    0.005},      
+  {{dict,new,0},                                  5,    0.015,    0.010},      
+  {{erl_lint,'-start/2-lc$^1/1-1-',1},            1,    0.007,    0.003},      
+  {{ordsets,is_element,2},                        1,    0.006,    0.001},      
+  {{sets,new,0},                                  1,    0.003,    0.002},      
+  {{gb_sets,empty,0},                             3,    0.003,    0.003},      
+  {{erl_lint,pseudolocals,0},                     3,    0.003,    0.003},      
+  {{erl_lint,value_option,7},                     1,    0.002,    0.001}]}.    
+
+{[{{erl_eval,expr,5},                             1,    0.213,    0.003}],     
+ { {erl_eval,hide_calls,2},                       1,    0.213,    0.003},     %
+ [{{erl_eval,hide,3},                             1,    0.206,    0.086},      
+  {{dict,new,0},                                  1,    0.004,    0.003}]}.    
+
+{[{{erl_eval,hide_calls,2},                       1,    0.206,    0.086},      
+  {{erl_eval,hide,3},                            68,    0.000,    0.104}],     
+ { {erl_eval,hide,3},                            69,    0.206,    0.190},     %
+ [{{erlang,tuple_to_list,1},                      8,    0.008,    0.008},      
+  {{erlang,list_to_tuple,1},                      8,    0.008,    0.008},      
+  {{erl_eval,hide,3},                            68,    0.000,    0.104}]}.    
+
+{[{{erl_lint,used_vars,2},                        1,    0.192,    0.005},      
+  {{erl_lint,fun_clause,3},                       1,    0.000,    0.005},      
+  {{erl_lint,exprs,3},                            2,    0.000,    0.002}],     
+ { {erl_lint,exprs,3},                            4,    0.192,    0.012},     %
+ [{{erl_lint,expr,3},                             2,    0.182,    0.028},      
+  {{erl_lint,vtupdate,2},                         4,    0.008,    0.004},      
+  {{erl_lint,exprs,3},                            2,    0.000,    0.002}]}.    
+
+{[{{erl_lint,exprs,3},                            2,    0.182,    0.028},      
+  {{erl_lint,'-expr_list/3-fun-0-',3},            1,    0.000,    0.001}],     
+ { {erl_lint,expr,3},                             3,    0.182,    0.029},     %
+ [{{erl_lint,fun_clauses,3},                      1,    0.181,    0.006},      
+  {{erl_lint,expr_list,3},                        1,    0.020,    0.005},      
+  {{erl_lint,keyword_warning,3},                  1,    0.016,    0.016},      
+  {{erl_lint,check_remote_function,5},            1,    0.013,    0.003}]}.    
+
+{[{{erl_lint,expr,3},                             1,    0.181,    0.006}],     
+ { {erl_lint,fun_clauses,3},                      1,    0.181,    0.006},     %
+ [{{lists,foldl,3},                               1,    0.169,    0.002},      
+  {{erlang,setelement,3},                         2,    0.002,    0.002},      
+  {{erl_lint,vtold,2},                            1,    0.002,    0.001},      
+  {{erl_lint,vt_no_unused,1},                     1,    0.002,    0.001}]}.    
+
+{[{{lists,foldl,3},                               1,    0.166,    0.003}],     
+ { {erl_lint,'-fun_clauses/3-fun-0-',3},          1,    0.166,    0.003},     %
+ [{{erl_lint,fun_clause,3},                       1,    0.161,    0.016},      
+  {{erl_lint,vtmerge,2},                          1,    0.002,    0.001}]}.    
+
+{[{{erl_lint,'-fun_clauses/3-fun-0-',3},          1,    0.161,    0.016}],     
+ { {erl_lint,fun_clause,3},                       1,    0.161,    0.016},     %
+ [{{erl_lint,shadow_vars,4},                      1,    0.015,    0.004},      
+  {{erl_lint,check_old_unused_vars,3},            1,    0.011,    0.003},      
+  {{erl_lint,vtupdate,2},                         4,    0.010,    0.005},      
+  {{erl_lint,check_unused_vars,3},                1,    0.008,    0.002},      
+  {{erl_lint,vtsubtract,2},                       2,    0.006,    0.002},      
+  {{erl_lint,vtold,2},                            2,    0.004,    0.002},      
+  {{erl_lint,vtmerge,2},                          1,    0.002,    0.001},      
+  {{erl_lint,guard,3},                            1,    0.002,    0.001},      
+  {{erl_lint,head,4},                             1,    0.001,    0.001},      
+  {{erl_lint,exprs,3},                            1,    0.000,    0.005}]}.    
+
+{[{{erl_lint,used_vars,2},                        1,    0.147,    0.001}],     
+ { {erl_lint,zip_file_and_line,2},                1,    0.147,    0.001},     %
+ [{{erl_lint,modify_line,2},                      1,    0.146,    0.001}]}.    
+
+{[{{erl_lint,zip_file_and_line,2},                1,    0.146,    0.001}],     
+ { {erl_lint,modify_line,2},                      1,    0.146,    0.001},     %
+ [{{erl_lint,modify_line1,2},                     1,    0.145,    0.021}]}.    
+
+{[{{erl_lint,modify_line,2},                      1,    0.145,    0.021},      
+  {{erl_lint,modify_line1,2},                    20,    0.000,    0.067}],     
+ { {erl_lint,modify_line1,2},                    21,    0.145,    0.088},     %
+ [{{erl_lint,'-zip_file_and_line/2-fun-1-',2},    7,    0.057,    0.007},      
+  {{erl_lint,modify_line1,2},                    20,    0.000,    0.067}]}.    
+
+{[{{erl_lint,modify_line1,2},                     7,    0.057,    0.007}],     
+ { {erl_lint,'-zip_file_and_line/2-fun-1-',2},    7,    0.057,    0.007},     %
+ [{{erl_parse,set_line,2},                        7,    0.050,    0.007}]}.    
+
+{[{{erl_lint,'-zip_file_and_line/2-fun-1-',2},    7,    0.050,    0.007}],     
+ { {erl_parse,set_line,2},                        7,    0.050,    0.007},     %
+ [{{erl_scan,set_attribute,3},                    7,    0.043,    0.020}]}.    
+
+{[{{erl_lint,start,2},                            1,    0.049,    0.002}],     
+ { {dict,from_list,1},                            1,    0.049,    0.002},     %
+ [{{lists,foldl,3},                               1,    0.044,    0.002},      
+  {{dict,new,0},                                  1,    0.003,    0.002}]}.    
+
+{[{{erl_parse,set_line,2},                        7,    0.043,    0.020}],     
+ { {erl_scan,set_attribute,3},                    7,    0.043,    0.020},     %
+ [{{erl_scan,set_attr,3},                         7,    0.023,    0.016}]}.    
+
+{[{{lists,foldl,3},                               1,    0.041,    0.001}],     
+ { {dict,'-from_list/1-fun-0-',2},                1,    0.041,    0.001},     %
+ [{{dict,store,3},                                1,    0.040,    0.003}]}.    
+
+{[{{dict,'-from_list/1-fun-0-',2},                1,    0.040,    0.003}],     
+ { {dict,store,3},                                1,    0.040,    0.003},     %
+ [{{dict,on_bucket,3},                            1,    0.030,    0.025},      
+  {{dict,maybe_expand,2},                         1,    0.004,    0.001},      
+  {{dict,get_slot,2},                             1,    0.003,    0.002}]}.    
+
+{[{{fprof,just_call,2},                           1,    0.039,    0.039}],     
+ { {erlang,demonitor,1},                          1,    0.039,    0.039},     %
+ [ ]}.
+
+{[{{erl_lint,start,2},                            1,    0.026,    0.001},      
+  {{gb_sets,from_list,1},                         2,    0.004,    0.002}],     
+ { {ordsets,from_list,1},                         3,    0.030,    0.003},     %
+ [{{lists,usort,1},                               3,    0.027,    0.003}]}.    
+
+{[{{dict,store,3},                                1,    0.030,    0.025}],     
+ { {dict,on_bucket,3},                            1,    0.030,    0.025},     %
+ [{{erlang,setelement,3},                         3,    0.003,    0.003},      
+  {{dict,'-store/3-fun-0-',3},                    1,    0.002,    0.001}]}.    
+
+{[{{erl_eval,expr,5},                             3,    0.017,    0.008},      
+  {{erl_eval,expr_list,6},                        3,    0.012,    0.006}],     
+ { {erl_eval,merge_bindings,2},                   6,    0.029,    0.014},     %
+ [{{orddict,to_list,1},                           6,    0.008,    0.008},      
+  {{lists,foldl,3},                               6,    0.007,    0.007}]}.    
+
+{[{{erl_lint,start,2},                           14,    0.028,    0.014}],     
+ { {erl_lint,bool_option,4},                     14,    0.028,    0.014},     %
+ [{{lists,foldl,3},                              14,    0.014,    0.014}]}.    
+
+{[{{ordsets,from_list,1},                         3,    0.027,    0.003}],     
+ { {lists,usort,1},                               3,    0.027,    0.003},     %
+ [{{lists,usplit_2,5},                            1,    0.024,    0.001}]}.    
+
+{[{{erl_lint,start,2},                            2,    0.026,    0.004}],     
+ { {gb_sets,from_list,1},                         2,    0.026,    0.004},     %
+ [{{gb_sets,from_ordset,1},                       2,    0.018,    0.004},      
+  {{ordsets,from_list,1},                         2,    0.004,    0.002}]}.    
+
+{[{{lists,usort,1},                               1,    0.024,    0.001},      
+  {{lists,usplit_2_1,6},                          1,    0.000,    0.001},      
+  {{lists,usplit_2,5},                            3,    0.000,    0.003}],     
+ { {lists,usplit_2,5},                            5,    0.024,    0.005},     %
+ [{{lists,usplit_2_1,6},                          1,    0.021,    0.001},      
+  {{lists,umergel,3},                             1,    0.017,    0.002},      
+  {{lists,usplit_2,5},                            3,    0.000,    0.003}]}.    
+
+{[{{erl_eval,do_apply,6},                         1,    0.024,    0.002}],     
+ { {fprof,trace,1},                               1,    0.024,    0.002},     %
+ [{{fprof,call,1},                                1,    0.022,    0.006}]}.    
+
+{[{{erl_scan,set_attribute,3},                    7,    0.023,    0.016}],     
+ { {erl_scan,set_attr,3},                         7,    0.023,    0.016},     %
+ [{{erl_lint,'-zip_file_and_line/2-fun-0-',2},    7,    0.007,    0.007}]}.    
+
+{[{{erl_lint,start,2},                            1,    0.023,    0.005},      
+  {{erl_lint,'-start/2-lc$^0/1-0-',1},           14,    0.000,    0.018}],     
+ { {erl_lint,'-start/2-lc$^0/1-0-',1},           15,    0.023,    0.023},     %
+ [{{erl_lint,'-start/2-lc$^0/1-0-',1},           14,    0.000,    0.018}]}.    
+
+{[{{fprof,trace,1},                               1,    0.022,    0.006}],     
+ { {fprof,call,1},                                1,    0.022,    0.006},     %
+ [{{fprof,just_call,2},                           1,    0.013,    0.009},      
+  {{erlang,whereis,1},                            1,    0.003,    0.003}]}.    
+
+{[{{erl_lint,start,2},                            5,    0.015,    0.010},      
+  {{erl_eval,hide_calls,2},                       1,    0.004,    0.003},      
+  {{dict,from_list,1},                            1,    0.003,    0.002}],     
+ { {dict,new,0},                                  7,    0.022,    0.015},     %
+ [{{dict,mk_seg,1},                               7,    0.007,    0.007}]}.    
+
+{[{{lists,usplit_2,5},                            1,    0.021,    0.001},      
+  {{lists,usplit_2_1,6},                          1,    0.000,    0.001}],     
+ { {lists,usplit_2_1,6},                          2,    0.021,    0.002},     %
+ [{{lists,usplit_2_1,6},                          1,    0.000,    0.001},      
+  {{lists,usplit_2,5},                            1,    0.000,    0.001}]}.    
+
+{[{{erl_lint,expr,3},                             1,    0.020,    0.005}],     
+ { {erl_lint,expr_list,3},                        1,    0.020,    0.005},     %
+ [{{erl_lint,vtold,2},                            1,    0.002,    0.001},      
+  {{erl_lint,vtnew,2},                            1,    0.002,    0.001},      
+  {{erl_lint,vtmerge,2},                          1,    0.002,    0.001},      
+  {{lists,foldl,3},                               1,    0.000,    0.002}]}.    
+
+{[{{gb_sets,from_list,1},                         2,    0.018,    0.004}],     
+ { {gb_sets,from_ordset,1},                       2,    0.018,    0.004},     %
+ [{{gb_sets,balance_list,2},                      2,    0.014,    0.004}]}.    
+
+{[{{erl_lint,fun_clause,3},                       4,    0.010,    0.005},      
+  {{erl_lint,exprs,3},                            4,    0.008,    0.004}],     
+ { {erl_lint,vtupdate,2},                         8,    0.018,    0.009},     %
+ [{{orddict,merge,3},                             8,    0.008,    0.008},      
+  {garbage_collect,                               1,    0.001,    0.001}]}.    
+
+{[{{lists,usplit_2,5},                            1,    0.017,    0.002},      
+  {{lists,umergel,3},                             1,    0.000,    0.001},      
+  {{lists,rumergel,3},                            1,    0.000,    0.001}],     
+ { {lists,umergel,3},                             3,    0.017,    0.004},     %
+ [{{lists,umerge2_2,4},                           1,    0.010,    0.001},      
+  {{lists,rumergel,3},                            1,    0.004,    0.002},      
+  {{lists,umergel,3},                             1,    0.000,    0.001}]}.    
+
+{[{{erl_lint,expr,3},                             1,    0.016,    0.016}],     
+ { {erl_lint,keyword_warning,3},                  1,    0.016,    0.016},     %
+ [ ]}.
+
+{[{{erl_lint,fun_clause,3},                       1,    0.015,    0.004}],     
+ { {erl_lint,shadow_vars,4},                      1,    0.015,    0.004},     %
+ [{{erl_lint,is_warn_enabled,2},                  1,    0.006,    0.001},      
+  {{erl_lint,vtold,2},                            1,    0.002,    0.001},      
+  {{erl_lint,vt_no_unsafe,1},                     1,    0.002,    0.001},      
+  {{lists,foldl,3},                               1,    0.000,    0.001}]}.    
+
+{[{{erl_lint,vtold,2},                            6,    0.006,    0.006},      
+  {{erl_lint,vtnew,2},                            5,    0.005,    0.005},      
+  {{erl_lint,unused_vars,3},                      2,    0.002,    0.002},      
+  {{erl_eval,expr,5},                             1,    0.001,    0.001}],     
+ { {orddict,filter,2},                           14,    0.014,    0.014},     %
+ [ ]}.
+
+{[{{gb_sets,from_ordset,1},                       2,    0.014,    0.004}],     
+ { {gb_sets,balance_list,2},                      2,    0.014,    0.004},     %
+ [{{gb_sets,balance_list_1,2},                    2,    0.010,    0.006}]}.    
+
+{[{{erl_eval,expr,5},                             9,    0.009,    0.009},      
+  {{erl_eval,do_apply,6},                         2,    0.004,    0.004},      
+  {{fprof,just_call,2},                           1,    0.001,    0.001}],     
+ { {erl_eval,ret_expr,3},                        12,    0.014,    0.014},     %
+ [ ]}.
+
+{[{{erl_lint,expr,3},                             1,    0.013,    0.003}],     
+ { {erl_lint,check_remote_function,5},            1,    0.013,    0.003},     %
+ [{{erl_lint,deprecated_function,5},              1,    0.006,    0.003},      
+  {{erl_lint,format_function,5},                  1,    0.003,    0.002},      
+  {{erl_lint,check_qlc_hrl,5},                    1,    0.001,    0.001}]}.    
+
+{[{{erl_lint,vtupdate,2},                         8,    0.008,    0.008},      
+  {{erl_lint,vtmerge,2},                          3,    0.003,    0.003},      
+  {{erl_lint,vtmerge_pat,2},                      1,    0.001,    0.001}],     
+ { {orddict,merge,3},                            12,    0.012,    0.012},     %
+ [ ]}.
+
+{[{{erl_lint,fun_clause,3},                       2,    0.004,    0.002},      
+  {{erl_lint,shadow_vars,4},                      1,    0.002,    0.001},      
+  {{erl_lint,fun_clauses,3},                      1,    0.002,    0.001},      
+  {{erl_lint,expr_list,3},                        1,    0.002,    0.001},      
+  {{erl_lint,check_old_unused_vars,3},            1,    0.002,    0.001}],     
+ { {erl_lint,vtold,2},                            6,    0.012,    0.006},     %
+ [{{orddict,filter,2},                            6,    0.006,    0.006}]}.    
+
+{[{{erl_lint,start,2},                            1,    0.006,    0.001},      
+  {{erl_lint,is_warn_enabled,2},                  1,    0.005,    0.001},      
+  {{ordsets,is_element,2},                        9,    0.000,    0.009}],     
+ { {ordsets,is_element,2},                       11,    0.011,    0.011},     %
+ [{{ordsets,is_element,2},                        9,    0.000,    0.009}]}.    
+
+{[{{erl_lint,fun_clause,3},                       1,    0.011,    0.003}],     
+ { {erl_lint,check_old_unused_vars,3},            1,    0.011,    0.003},     %
+ [{{erl_lint,unused_vars,3},                      1,    0.005,    0.002},      
+  {{erl_lint,vtold,2},                            1,    0.002,    0.001},      
+  {{erl_lint,warn_unused_vars,3},                 1,    0.001,    0.001}]}.    
+
+{[{{lists,umergel,3},                             1,    0.010,    0.001},      
+  {{lists,umerge2_2,4},                           1,    0.000,    0.001},      
+  {{lists,umerge2_1,5},                           2,    0.000,    0.003}],     
+ { {lists,umerge2_2,4},                           4,    0.010,    0.005},     %
+ [{{lists,umerge2_1,5},                           2,    0.009,    0.002},      
+  {{lists,reverse,2},                             1,    0.001,    0.001},      
+  {{lists,umerge2_2,4},                           1,    0.000,    0.001}]}.    
+
+{[{{gb_sets,balance_list,2},                      2,    0.010,    0.006},      
+  {{gb_sets,balance_list_1,2},                    4,    0.000,    0.004}],     
+ { {gb_sets,balance_list_1,2},                    6,    0.010,    0.010},     %
+ [{{gb_sets,balance_list_1,2},                    4,    0.000,    0.004}]}.    
+
+{[{{erl_lint,vtsubtract,2},                       2,    0.004,    0.002},      
+  {{erl_lint,unused_vars,3},                      2,    0.004,    0.002},      
+  {{erl_lint,expr_list,3},                        1,    0.002,    0.001}],     
+ { {erl_lint,vtnew,2},                            5,    0.010,    0.005},     %
+ [{{orddict,filter,2},                            5,    0.005,    0.005}]}.    
+
+{[{{erl_lint,check_unused_vars,3},                1,    0.005,    0.002},      
+  {{erl_lint,check_old_unused_vars,3},            1,    0.005,    0.002}],     
+ { {erl_lint,unused_vars,3},                      2,    0.010,    0.004},     %
+ [{{erl_lint,vtnew,2},                            2,    0.004,    0.002},      
+  {{orddict,filter,2},                            2,    0.002,    0.002}]}.    
+
+{[{{lists,umerge2_2,4},                           2,    0.009,    0.002},      
+  {{lists,umerge2_1,5},                           2,    0.000,    0.002}],     
+ { {lists,umerge2_1,5},                           4,    0.009,    0.004},     %
+ [{{lists,umerge2_2,4},                           2,    0.000,    0.003},      
+  {{lists,umerge2_1,5},                           2,    0.000,    0.002}]}.    
+
+{[{{erl_eval,merge_bindings,2},                   6,    0.008,    0.008}],     
+ { {orddict,to_list,1},                           6,    0.008,    0.008},     %
+ [ ]}.
+
+{[{{erl_eval,hide,3},                             8,    0.008,    0.008}],     
+ { {erlang,tuple_to_list,1},                      8,    0.008,    0.008},     %
+ [ ]}.
+
+{[{{erl_eval,hide,3},                             8,    0.008,    0.008}],     
+ { {erlang,list_to_tuple,1},                      8,    0.008,    0.008},     %
+ [ ]}.
+
+{[{{erl_lint,fun_clause,3},                       1,    0.008,    0.002}],     
+ { {erl_lint,check_unused_vars,3},                1,    0.008,    0.002},     %
+ [{{erl_lint,unused_vars,3},                      1,    0.005,    0.002},      
+  {{erl_lint,warn_unused_vars,3},                 1,    0.001,    0.001}]}.    
+
+{[{{erl_eval,expr,5},                             1,    0.008,    0.001}],     
+ { {erl_eval,bif,5},                              1,    0.008,    0.001},     %
+ [{{erl_eval,do_apply,6},                         1,    0.007,    0.002}]}.    
+
+{[{{erl_scan,set_attr,3},                         7,    0.007,    0.007}],     
+ { {erl_lint,'-zip_file_and_line/2-fun-0-',2},    7,    0.007,    0.007},     %
+ [ ]}.
+
+{[{{erl_lint,start,2},                            1,    0.007,    0.003},      
+  {{erl_lint,'-start/2-lc$^1/1-1-',1},            3,    0.000,    0.004}],     
+ { {erl_lint,'-start/2-lc$^1/1-1-',1},            4,    0.007,    0.007},     %
+ [{{erl_lint,'-start/2-lc$^1/1-1-',1},            3,    0.000,    0.004}]}.    
+
+{[{{dict,new,0},                                  7,    0.007,    0.007}],     
+ { {dict,mk_seg,1},                               7,    0.007,    0.007},     %
+ [ ]}.
+
+{[{{dict,on_bucket,3},                            3,    0.003,    0.003},      
+  {{erl_lint,fun_clauses,3},                      2,    0.002,    0.002},      
+  {{dict,maybe_expand_aux,2},                     1,    0.001,    0.001}],     
+ { {erlang,setelement,3},                         6,    0.006,    0.006},     %
+ [ ]}.
+
+{[{{erl_lint,fun_clause,3},                       2,    0.006,    0.002}],     
+ { {erl_lint,vtsubtract,2},                       2,    0.006,    0.002},     %
+ [{{erl_lint,vtnew,2},                            2,    0.004,    0.002}]}.    
+
+{[{{erl_lint,fun_clause,3},                       1,    0.002,    0.001},      
+  {{erl_lint,expr_list,3},                        1,    0.002,    0.001},      
+  {{erl_lint,'-fun_clauses/3-fun-0-',3},          1,    0.002,    0.001}],     
+ { {erl_lint,vtmerge,2},                          3,    0.006,    0.003},     %
+ [{{orddict,merge,3},                             3,    0.003,    0.003}]}.    
+
+{[{{erl_lint,shadow_vars,4},                      1,    0.006,    0.001}],     
+ { {erl_lint,is_warn_enabled,2},                  1,    0.006,    0.001},     %
+ [{{ordsets,is_element,2},                        1,    0.005,    0.001}]}.    
+
+{[{{erl_lint,check_remote_function,5},            1,    0.006,    0.003}],     
+ { {erl_lint,deprecated_function,5},              1,    0.006,    0.003},     %
+ [{{otp_internal,obsolete,3},                     1,    0.003,    0.002}]}.    
+
+{[{{lists,foldl,3},                               1,    0.006,    0.003}],     
+ { {erl_lint,'-expr_list/3-fun-0-',3},            1,    0.006,    0.003},     %
+ [{{erl_lint,vtmerge_pat,2},                      1,    0.002,    0.001},      
+  {{erl_lint,expr,3},                             1,    0.000,    0.001}]}.    
+
+{[{{lists,umergel,3},                             1,    0.004,    0.002}],     
+ { {lists,rumergel,3},                            1,    0.004,    0.002},     %
+ [{{lists,reverse,2},                             1,    0.001,    0.001},      
+  {{lists,umergel,3},                             1,    0.000,    0.001}]}.    
+
+{[{{erl_eval,expr_list,6},                        3,    0.004,    0.004}],     
+ { {lists,reverse,1},                             3,    0.004,    0.004},     %
+ [ ]}.
+
+{[{{fprof,call,1},                                1,    0.003,    0.003},      
+  {{error_handler,ensure_loaded,1},               1,    0.001,    0.001}],     
+ { {erlang,whereis,1},                            2,    0.004,    0.004},     %
+ [ ]}.
+
+{[{{erl_eval,do_apply,6},                         1,    0.004,    0.002}],     
+ { {erlang,spawn,1},                              1,    0.004,    0.002},     %
+ [{{erlang,spawn,3},                              1,    0.002,    0.002}]}.    
+
+{[{{fprof,just_call,2},                           1,    0.004,    0.004}],     
+ { {erlang,monitor,2},                            1,    0.004,    0.004},     %
+ [ ]}.
+
+{[{{dict,store,3},                                1,    0.004,    0.001}],     
+ { {dict,maybe_expand,2},                         1,    0.004,    0.001},     %
+ [{{dict,maybe_expand_aux,2},                     1,    0.003,    0.002}]}.    
+
+{[{{erl_lint,start,2},                            1,    0.003,    0.002}],     
+ { {sets,new,0},                                  1,    0.003,    0.002},     %
+ [{{sets,mk_seg,1},                               1,    0.001,    0.001}]}.    
+
+{[{{erl_lint,deprecated_function,5},              1,    0.003,    0.002}],     
+ { {otp_internal,obsolete,3},                     1,    0.003,    0.002},     %
+ [{{otp_internal,obsolete_1,3},                   1,    0.001,    0.001}]}.    
+
+{[{{erl_lint,start,2},                            3,    0.003,    0.003}],     
+ { {gb_sets,empty,0},                             3,    0.003,    0.003},     %
+ [ ]}.
+
+{[{{erl_lint,start,2},                            3,    0.003,    0.003}],     
+ { {erl_lint,pseudolocals,0},                     3,    0.003,    0.003},     %
+ [ ]}.
+
+{[{{erl_lint,check_remote_function,5},            1,    0.003,    0.002}],     
+ { {erl_lint,format_function,5},                  1,    0.003,    0.002},     %
+ [{{erl_lint,is_format_function,2},               1,    0.001,    0.001}]}.    
+
+{[{{erl_eval,expr,5},                             2,    0.003,    0.003}],     
+ { {erl_internal,bif,3},                          2,    0.003,    0.003},     %
+ [ ]}.
+
+{[{{dict,maybe_expand,2},                         1,    0.003,    0.002}],     
+ { {dict,maybe_expand_aux,2},                     1,    0.003,    0.002},     %
+ [{{erlang,setelement,3},                         1,    0.001,    0.001}]}.    
+
+{[{{dict,store,3},                                1,    0.003,    0.002}],     
+ { {dict,get_slot,2},                             1,    0.003,    0.002},     %
+ [{{erlang,phash,2},                              1,    0.001,    0.001}]}.    
+
+{[{{lists,umerge2_2,4},                           1,    0.001,    0.001},      
+  {{lists,rumergel,3},                            1,    0.001,    0.001}],     
+ { {lists,reverse,2},                             2,    0.002,    0.002},     %
+ [ ]}.
+
+{[{{erlang,spawn,1},                              1,    0.002,    0.002}],     
+ { {erlang,spawn,3},                              1,    0.002,    0.002},     %
+ [ ]}.
+
+{[{{erl_lint,check_unused_vars,3},                1,    0.001,    0.001},      
+  {{erl_lint,check_old_unused_vars,3},            1,    0.001,    0.001}],     
+ { {erl_lint,warn_unused_vars,3},                 2,    0.002,    0.002},     %
+ [ ]}.
+
+{[{{erl_lint,'-expr_list/3-fun-0-',3},            1,    0.002,    0.001}],     
+ { {erl_lint,vtmerge_pat,2},                      1,    0.002,    0.001},     %
+ [{{orddict,merge,3},                             1,    0.001,    0.001}]}.    
+
+{[{{erl_lint,fun_clauses,3},                      1,    0.002,    0.001}],     
+ { {erl_lint,vt_no_unused,1},                     1,    0.002,    0.001},     %
+ [{{erl_lint,'-vt_no_unused/1-lc$^0/1-0-',1},     1,    0.001,    0.001}]}.    
+
+{[{{erl_lint,shadow_vars,4},                      1,    0.002,    0.001}],     
+ { {erl_lint,vt_no_unsafe,1},                     1,    0.002,    0.001},     %
+ [{{erl_lint,'-vt_no_unsafe/1-lc$^0/1-0-',1},     1,    0.001,    0.001}]}.    
+
+{[{{erl_lint,start,2},                            1,    0.002,    0.001}],     
+ { {erl_lint,value_option,7},                     1,    0.002,    0.001},     %
+ [{{lists,foldl,3},                               1,    0.001,    0.001}]}.    
+
+{[{{erl_lint,fun_clause,3},                       1,    0.002,    0.001}],     
+ { {erl_lint,guard,3},                            1,    0.002,    0.001},     %
+ [{{erl_lint,guard_tests,3},                      1,    0.001,    0.001}]}.    
+
+{[{{dict,on_bucket,3},                            1,    0.002,    0.001}],     
+ { {dict,'-store/3-fun-0-',3},                    1,    0.002,    0.001},     %
+ [{{dict,store_bkt_val,3},                        1,    0.001,    0.001}]}.    
+
+{[{{sets,new,0},                                  1,    0.001,    0.001}],     
+ { {sets,mk_seg,1},                               1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{otp_internal,obsolete,3},                     1,    0.001,    0.001}],     
+ { {otp_internal,obsolete_1,3},                   1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{erl_lint,used_vars,2},                        1,    0.001,    0.001}],     
+ { {orddict,from_list,1},                         1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{dict,get_slot,2},                             1,    0.001,    0.001}],     
+ { {erlang,phash,2},                              1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{error_handler,undefined_function,3},          1,    0.001,    0.001}],     
+ { {erlang,function_exported,3},                  1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{erl_lint,format_function,5},                  1,    0.001,    0.001}],     
+ { {erl_lint,is_format_function,2},               1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{erl_lint,fun_clause,3},                       1,    0.001,    0.001}],     
+ { {erl_lint,head,4},                             1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{erl_lint,guard,3},                            1,    0.001,    0.001}],     
+ { {erl_lint,guard_tests,3},                      1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{erl_lint,check_remote_function,5},            1,    0.001,    0.001}],     
+ { {erl_lint,check_qlc_hrl,5},                    1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{erl_lint,vt_no_unused,1},                     1,    0.001,    0.001}],     
+ { {erl_lint,'-vt_no_unused/1-lc$^0/1-0-',1},     1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{erl_lint,vt_no_unsafe,1},                     1,    0.001,    0.001}],     
+ { {erl_lint,'-vt_no_unsafe/1-lc$^0/1-0-',1},     1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{erl_eval,expr,5},                             1,    0.001,    0.001}],     
+ { {erl_internal,bif,2},                          1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{dict,'-store/3-fun-0-',3},                    1,    0.001,    0.001}],     
+ { {dict,store_bkt_val,3},                        1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{erl_lint,vtupdate,2},                         1,    0.001,    0.001}],     
+ { garbage_collect,                               1,    0.001,    0.001},     %
+ [ ]}.
+
+{[ ],
+ { undefined,                                     0,    0.000,    0.000},     %
+ [{{erl_eval,local_func,5},                       0,   23.833,    0.000},      
+  {{fprof,just_call,2},                           0,    0.427,    0.388},      
+  {{escript,eval_exprs,5},                        0,    0.004,    0.000}]}.    
+
+
+%                                               CNT       ACC       OWN        
+[{ "<0.33.0>",                                   43,undefined,    0.156},    %%
+ { spawned_by, "<0.2.0>"},
+ { spawned_as, {erlang,apply,["#Fun<erl_eval.20.106461118>",[]]}},
+ { initial_calls, [{erlang,apply,2},{erl_eval,'-expr/5-fun-3-',1}]}].
+
+{[{undefined,                                     1,   13.148,    0.003}],     
+ { {erlang,apply,2},                              1,   13.148,    0.003},     %
+ [{{erl_eval,'-expr/5-fun-3-',1},                 1,   13.102,    0.009},      
+  {suspend,                                       1,    0.043,    0.000}]}.    
+
+{[{{erlang,apply,2},                              1,   13.102,    0.009}],     
+ { {erl_eval,'-expr/5-fun-3-',1},                 1,   13.102,    0.009},     %
+ [{{erl_eval,eval_fun,2},                         1,   13.093,    0.001}]}.    
+
+{[{{erl_eval,'-expr/5-fun-3-',1},                 1,   13.093,    0.001}],     
+ { {erl_eval,eval_fun,2},                         1,   13.093,    0.001},     %
+ [{{erl_eval,eval_fun,6},                         1,   13.092,    0.023}]}.    
+
+{[{{erl_eval,eval_fun,2},                         1,   13.092,    0.023}],     
+ { {erl_eval,eval_fun,6},                         1,   13.092,    0.023},     %
+ [{{erl_eval,exprs,5},                            1,   13.060,    0.001},      
+  {{erl_eval,add_bindings,2},                     1,    0.004,    0.002},      
+  {{erl_eval,new_bindings,0},                     1,    0.002,    0.001},      
+  {{erl_eval,guard,4},                            1,    0.002,    0.001},      
+  {{erl_eval,match_list,4},                       1,    0.001,    0.001}]}.    
+
+{[{{erl_eval,eval_fun,6},                         1,   13.060,    0.001}],     
+ { {erl_eval,exprs,5},                            1,   13.060,    0.001},     %
+ [{{erl_eval,expr,5},                             1,   13.059,    0.006}]}.    
+
+{[{{erl_eval,exprs,5},                            1,   13.059,    0.006},      
+  {{erl_eval,expr_list,6},                        1,    0.000,    0.001},      
+  {{erl_eval,expr,5},                             2,    0.000,    0.002}],     
+ { {erl_eval,expr,5},                             4,   13.059,    0.009},     %
+ [{{erl_eval,do_apply,6},                         1,   13.031,    0.001},      
+  {{erl_eval,expr_list,4},                        1,    0.013,    0.001},      
+  {{erl_eval,merge_bindings,2},                   1,    0.004,    0.002},      
+  {{erl_eval,ret_expr,3},                         3,    0.003,    0.003},      
+  {{erl_internal,bif,3},                          1,    0.001,    0.001},      
+  {{erl_eval,expr,5},                             2,    0.000,    0.002}]}.    
+
+{[{{erl_eval,expr,5},                             1,   13.031,    0.001}],     
+ { {erl_eval,do_apply,6},                         1,   13.031,    0.001},     %
+ [{{error_handler,undefined_function,3},          1,   13.030,    0.003}]}.    
+
+{[{{erl_eval,do_apply,6},                         1,   13.030,    0.003}],     
+ { {error_handler,undefined_function,3},          1,   13.030,    0.003},     %
+ [{{timer,sleep,1},                               1,   11.360,    0.069},      
+  {{error_handler,ensure_loaded,1},               1,    1.666,    0.002},      
+  {{erlang,function_exported,3},                  1,    0.001,    0.001}]}.    
+
+{[{{timer,sleep,1},                               1,   11.291,    0.000},      
+  {{code_server,call,2},                          1,    1.658,    0.000},      
+  {{erlang,apply,2},                              1,    0.043,    0.000}],     
+ { suspend,                                       3,   12.992,    0.000},     %
+ [ ]}.
+
+{[{{error_handler,undefined_function,3},          1,   11.360,    0.069}],     
+ { {timer,sleep,1},                               1,   11.360,    0.069},     %
+ [{suspend,                                       1,   11.291,    0.000}]}.    
+
+{[{{error_handler,undefined_function,3},          1,    1.666,    0.002}],     
+ { {error_handler,ensure_loaded,1},               1,    1.666,    0.002},     %
+ [{{code,ensure_loaded,1},                        1,    1.663,    0.001},      
+  {{erlang,whereis,1},                            1,    0.001,    0.001}]}.    
+
+{[{{error_handler,ensure_loaded,1},               1,    1.663,    0.001}],     
+ { {code,ensure_loaded,1},                        1,    1.663,    0.001},     %
+ [{{code,call,1},                                 1,    1.662,    0.001}]}.    
+
+{[{{code,ensure_loaded,1},                        1,    1.662,    0.001}],     
+ { {code,call,1},                                 1,    1.662,    0.001},     %
+ [{{code_server,call,2},                          1,    1.661,    0.003}]}.    
+
+{[{{code,call,1},                                 1,    1.661,    0.003}],     
+ { {code_server,call,2},                          1,    1.661,    0.003},     %
+ [{suspend,                                       1,    1.658,    0.000}]}.    
+
+{[{{erl_eval,expr,5},                             1,    0.013,    0.001}],     
+ { {erl_eval,expr_list,4},                        1,    0.013,    0.001},     %
+ [{{erl_eval,expr_list,6},                        1,    0.012,    0.003}]}.    
+
+{[{{erl_eval,expr_list,4},                        1,    0.012,    0.003},      
+  {{erl_eval,expr_list,6},                        1,    0.000,    0.002}],     
+ { {erl_eval,expr_list,6},                        2,    0.012,    0.005},     %
+ [{{erl_eval,merge_bindings,2},                   1,    0.004,    0.002},      
+  {{lists,reverse,1},                             1,    0.001,    0.001},      
+  {{erl_eval,expr_list,6},                        1,    0.000,    0.002},      
+  {{erl_eval,expr,5},                             1,    0.000,    0.001}]}.    
+
+{[{{erl_eval,expr_list,6},                        1,    0.004,    0.002},      
+  {{erl_eval,expr,5},                             1,    0.004,    0.002}],     
+ { {erl_eval,merge_bindings,2},                   2,    0.008,    0.004},     %
+ [{{orddict,to_list,1},                           2,    0.002,    0.002},      
+  {{lists,foldl,3},                               2,    0.002,    0.002}]}.    
+
+{[{{erl_eval,eval_fun,6},                         1,    0.004,    0.002}],     
+ { {erl_eval,add_bindings,2},                     1,    0.004,    0.002},     %
+ [{{orddict,to_list,1},                           1,    0.001,    0.001},      
+  {{lists,foldl,3},                               1,    0.001,    0.001}]}.    
+
+{[{{erl_eval,merge_bindings,2},                   2,    0.002,    0.002},      
+  {{erl_eval,add_bindings,2},                     1,    0.001,    0.001}],     
+ { {orddict,to_list,1},                           3,    0.003,    0.003},     %
+ [ ]}.
+
+{[{{erl_eval,merge_bindings,2},                   2,    0.002,    0.002},      
+  {{erl_eval,add_bindings,2},                     1,    0.001,    0.001}],     
+ { {lists,foldl,3},                               3,    0.003,    0.003},     %
+ [ ]}.
+
+{[{{erl_eval,expr,5},                             3,    0.003,    0.003}],     
+ { {erl_eval,ret_expr,3},                         3,    0.003,    0.003},     %
+ [ ]}.
+
+{[{{erl_eval,eval_fun,6},                         1,    0.002,    0.001}],     
+ { {erl_eval,new_bindings,0},                     1,    0.002,    0.001},     %
+ [{{orddict,new,0},                               1,    0.001,    0.001}]}.    
+
+{[{{erl_eval,eval_fun,6},                         1,    0.002,    0.001}],     
+ { {erl_eval,guard,4},                            1,    0.002,    0.001},     %
+ [{{erl_eval,guard0,4},                           1,    0.001,    0.001}]}.    
+
+{[{{erl_eval,new_bindings,0},                     1,    0.001,    0.001}],     
+ { {orddict,new,0},                               1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{erl_eval,expr_list,6},                        1,    0.001,    0.001}],     
+ { {lists,reverse,1},                             1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{error_handler,ensure_loaded,1},               1,    0.001,    0.001}],     
+ { {erlang,whereis,1},                            1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{error_handler,undefined_function,3},          1,    0.001,    0.001}],     
+ { {erlang,function_exported,3},                  1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{erl_eval,expr,5},                             1,    0.001,    0.001}],     
+ { {erl_internal,bif,3},                          1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{erl_eval,eval_fun,6},                         1,    0.001,    0.001}],     
+ { {erl_eval,match_list,4},                       1,    0.001,    0.001},     %
+ [ ]}.
+
+{[{{erl_eval,guard,4},                            1,    0.001,    0.001}],     
+ { {erl_eval,guard0,4},                           1,    0.001,    0.001},     %
+ [ ]}.
+
+{[ ],
+ { undefined,                                     0,    0.000,    0.000},     %
+ [{{erlang,apply,2},                              1,   13.148,    0.003}]}.    
+
+

--- a/src/erlgrind
+++ b/src/erlgrind
@@ -74,11 +74,19 @@ process_entry(OutFile, {_CallingList, Actual, CalledList}) ->
     process_actual(OutFile, Actual),
     process_called_list(OutFile, CalledList).
 
-process_actual(OutFile, {Func, _Cnt, _Acc, Own}) ->
+process_actual(OutFile, {Func, _Cnt, _Acc, _Own} = Actual) ->
     File = get_file(Func),
+    Time = actual_time(Actual),
     io:format(OutFile, "fl=~w~n", [File]),
     io:format(OutFile, "fn=~w~n", [Func]),
-    io:format(OutFile, "1 ~w~n", [trunc(Own*1000)]).
+    io:format(OutFile, "1 ~w~n", [Time]).
+
+actual_time({suspend, _Cnt, Acc, _Own}) ->
+    %% fprof doesn't include suspend time as own time, but kcachegrind needs a time value here
+    %% or total percents will add up to more than 100
+    trunc(Acc*1000);
+actual_time({_Func, _Cnt, _Acc, Own}) ->
+    trunc(Own*1000).
 
 process_called_list(_, []) ->
     ok;


### PR DESCRIPTION
This fixes an issue where the total run time could be greater than
100% if there was suspend time. Run the old version of the code on
suspend.fprof to see the problem.
